### PR TITLE
fix method retrieveAllAfterVersion

### DIFF
--- a/src/DoctrineMessageRepository.php
+++ b/src/DoctrineMessageRepository.php
@@ -115,7 +115,7 @@ class DoctrineMessageRepository implements MessageRepository
             ->select('payload')
             ->from($this->tableName)
             ->where('aggregate_root_id = :aggregate_root_id')
-            ->where('aggregate_root_version > :aggregate_root_version')
+            ->andWhere('aggregate_root_version > :aggregate_root_version')
             ->orderBy('aggregate_root_version', 'ASC')
             ->setParameter('aggregate_root_id', $id->toString())
             ->setParameter('aggregate_root_version', $aggregateRootVersion)

--- a/tests/DoctrineIntegrationTestCase.php
+++ b/tests/DoctrineIntegrationTestCase.php
@@ -94,8 +94,16 @@ abstract class DoctrineIntegrationTestCase extends TestCase
      */
     public function retrieving_messages_after_a_specific_version()
     {
-        $aggregateRootId = UuidAggregateRootId::create();
         $messages = [];
+
+        $aggregateRootIdConcurrent = UuidAggregateRootId::create();
+        $messages[] = $this->decorator->decorate(new Message(new TestEvent(), [
+            Header::EVENT_ID          => Uuid::uuid4()->toString(),
+            Header::AGGREGATE_ROOT_ID => $aggregateRootIdConcurrent->toString(),
+            Header::AGGREGATE_ROOT_VERSION => 15,
+        ]));
+
+        $aggregateRootId = UuidAggregateRootId::create();
         $messages[] = $this->decorator->decorate(new Message(new TestEvent(), [
             Header::EVENT_ID          => Uuid::uuid4()->toString(),
             Header::AGGREGATE_ROOT_ID => $aggregateRootId->toString(),
@@ -106,7 +114,9 @@ abstract class DoctrineIntegrationTestCase extends TestCase
             Header::AGGREGATE_ROOT_ID => $aggregateRootId->toString(),
             Header::AGGREGATE_ROOT_VERSION => 11,
         ]));
+
         $this->repository->persist(...$messages);
+
         $generator = $this->repository->retrieveAllAfterVersion($aggregateRootId, 10);
         /** @var Message[] $messages */
         $messages = iterator_to_array($generator);


### PR DESCRIPTION
The method `retrieveAllAfterVersion` is only filtering by version, so I  changed the query builder to filter by aggregate_root_id and version as expected.

Currently the second `where` is overwriting the first one, so when I print the SQL the result is this:

```sql
SELECT payload 
FROM domain_messages 
WHERE aggregate_root_version > :aggregate_root_version /* Only one WHERE */
ORDER BY aggregate_root_version ASC
```
And when I add the `andWhere` the printed SQL is this:

```sql
SELECT payload 
FROM domain_messages 
WHERE (aggregate_root_id = :aggregate_root_id) 
AND (aggregate_root_version > :aggregate_root_version) 
ORDER BY aggregate_root_version ASC
```
Can you please accept this PR? I didn't find any docs about how to contribute, so I'm sending like this :) if you have some suggestion, please let me know.

Tks! :)