### PR TITLE
Added `vimeo/psalm`, solved hard-crash with `doctrine/dbal:^2.12`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_script:
     - php tests/setup-postgres-schema.php
 
 script:
+    - vendor/bin/psalm
     - vendor/bin/phpunit --coverage-text
 
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "ramsey/uuid": "^3.6 || ^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5 || ^9"
+        "phpunit/phpunit": "^8.5 || ^9",
+        "vimeo/psalm": "^4.4"
     },
     "autoload": {
         "psr-4": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<psalm
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>


### PR DESCRIPTION
On `doctrine/dbal:2.12.x`, a `Doctrine\DBAL\Driver\ResultStatement` is passed
to `DoctrineMessageRepository#yieldMessagesForResult()`
instead of a `Doctrine\DBAL\Driver\Statement`.

Why? For the love and glory of Satan, of course :-) (I really have no clue)

To ensure that we avoid this sort of type-level problems, we hereby add
`vimeo/psalm` to the CI pipeline with some relatively strict defaults,
and adapted the code to remove bits that are detected as potentially
problematic.

In addition to that, the implementation now returns `Generator<Message>`,
instead of `Generator<mixed>`.